### PR TITLE
Changement de "Pour Ajouter" à "Remplir une demande d'hébergement"

### DIFF
--- a/_includes/sites_grid.html
+++ b/_includes/sites_grid.html
@@ -29,7 +29,7 @@
                   <img src="/img/sites/votre_site_thumb.jpg" alt="Votre site" class="img-responsive">
                 </a>
                 <div class="site-caption" style="max-height:71px;">
-                  <p>Pour Ajouter</p>
+                  <p>Remplir une demande d'hébergement...</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
C'est dans la section "Sites hébergés". C'est plus clair comme ça.
  