### PR TITLE
Load favicon with the appropriate protocol (http/https)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <!-- Add favicon for testing -->
-    <link rel='shortcut icon' href='http://cedille.etsmtl.ca/favicon.ico' type='image/x-icon'/ >
+    <link rel='shortcut icon' href='//cedille.etsmtl.ca/favicon.ico' type='image/x-icon'/ >
 
 
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->


### PR DESCRIPTION
The favicon should be loaded with the same protocol as the one used to initially load the page (http or https).