### PR TITLE
Remove phone contact information

### DIFF
--- a/_data/fr/contact.yml
+++ b/_data/fr/contact.yml
@@ -2,9 +2,6 @@ title: Contact
 description: Question? Commentaire? Envoyez-nous là par courriel ou venez nous rencontrer à notre local
 
 contact_informations:
-  phone:
-    title: Téléphone
-    value: (514) 396-8800 ext.7302
   email:
     title: Courriel
     value: cedille@etsmtl.net


### PR DESCRIPTION
On enlève le numéro de tel du site parce que ça fait pu vraiment de sens qu'on nous contacte comme ça. 

1- On est beaucoup moins au local pour répondre au téléphone que quand on avait notre propre local
2- On a pu le code de la messagerie du téléphone
3- Le téléphone a été débranché pendant toute la pandémie
